### PR TITLE
Add detailed siniestro documentation and repuestos workflows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import {
   reminders as initialReminders,
   notifications as initialNotifications,
   catalogSummary,
+  peritoInspections as initialPeritoInspections,
+  partsTracking as initialPartsTracking,
 } from './data/index.js';
 import {
   STATUS_ORDER,
@@ -51,6 +53,29 @@ function App() {
   });
   const [reminders, setReminders] = useState(() => [...initialReminders]);
   const [notifications] = useState(() => [...initialNotifications]);
+  const [peritoEntries] = useState(() =>
+    initialPeritoInspections.map((inspection) => ({
+      ...inspection,
+      damages: inspection.damages ? inspection.damages.map((damage) => ({ ...damage })) : [],
+      parts: inspection.parts ? inspection.parts.map((part) => ({ ...part })) : [],
+    })),
+  );
+  const [partsOrders] = useState(() =>
+    initialPartsTracking.map((order) => ({
+      ...order,
+      parts: order.parts
+        ? order.parts.map((part) => ({
+            ...part,
+            supplierQuotes: part.supplierQuotes
+              ? part.supplierQuotes.map((quote) => ({ ...quote }))
+              : [],
+          }))
+        : [],
+      adjustments: order.adjustments ? order.adjustments.map((adjustment) => ({ ...adjustment })) : [],
+      expansions: order.expansions ? order.expansions.map((expansion) => ({ ...expansion })) : [],
+      timeline: order.timeline ? order.timeline.map((item) => ({ ...item })) : [],
+    })),
+  );
   const [modal, setModal] = useState(null);
   const [toast, setToast] = useState(null);
   const [loginError, setLoginError] = useState('');
@@ -288,7 +313,7 @@ function App() {
     },
     repuestos: {
       title: 'Gestión de repuestos',
-      subtitle: 'Módulo en diseño: pedidos, aprobaciones y conciliación.',
+      subtitle: 'Seguimiento de pedidos, ajustes y entregas de repuestos.',
     },
     automatizaciones: {
       title: 'Automatizaciones y reglas',
@@ -338,12 +363,16 @@ function App() {
               onOpenClaim={openClaimDetailModal}
               alertEntries={alertEntries}
               automationTasks={automationTasks}
+              peritoInspections={peritoEntries}
+              onShowToast={showToast}
             />
           )}
           {activeModule === 'consultas' && (
             <ConsultasModule insuredDirectory={insuredDirectory} />
           )}
-          {activeModule === 'repuestos' && <PlaceholderModule />}
+          {activeModule === 'repuestos' && (
+            <RepuestosModule orders={partsOrders} onShowToast={showToast} />
+          )}
           {activeModule === 'automatizaciones' && (
             <AutomationsModule rules={automationRules} />
           )}
@@ -661,10 +690,66 @@ function SiniestrosModule({
   onOpenClaim,
   alertEntries,
   automationTasks,
+  peritoInspections,
+  onShowToast,
 }) {
   const handleChange = (event) => {
     const { name, value } = event.target;
     onFilterChange(name, value);
+  };
+
+  const inspections = peritoInspections ?? [];
+  const documentationAlerts = claims
+    .flatMap((claim) =>
+      (claim.documentation ?? []).map((document) => ({
+        claimId: claim.id,
+        ...document,
+      })),
+    )
+    .filter((document) => !['completo', 'no-aplica'].includes(document.status));
+  const expansions = claims.flatMap((claim) =>
+    (claim.expansions ?? []).map((expansion) => ({
+      claimId: claim.id,
+      ...expansion,
+    })),
+  );
+
+  const documentationStatusCopy = {
+    pendiente: { label: 'Pendiente', className: 'tag tag--danger' },
+    'en-proceso': { label: 'En proceso', className: 'tag tag--warning' },
+    completo: { label: 'Completo', className: 'tag tag--success' },
+    'no-aplica': { label: 'No aplica', className: 'tag' },
+  };
+
+  const getDocumentMeta = (status) => documentationStatusCopy[status] ?? { label: status, className: 'tag' };
+
+  const getExpansionMeta = (status) => {
+    if (!status) return { label: 'En análisis', className: 'tag tag--warning' };
+    const normalized = status.toLowerCase();
+    if (normalized.includes('aprob')) {
+      return { label: status, className: 'tag tag--success' };
+    }
+    if (normalized.includes('pend') || normalized.includes('revisión') || normalized.includes('revis')) {
+      return { label: status, className: 'tag tag--warning' };
+    }
+    if (normalized.includes('no aplica')) {
+      return { label: status, className: 'tag' };
+    }
+    return { label: status, className: 'tag' };
+  };
+
+  const handleCopyLink = async (link) => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(link);
+        onShowToast?.('Enlace copiado para enviar al perito.');
+        return;
+      }
+      throw new Error('Clipboard no disponible');
+    } catch (error) {
+      console.error(error);
+      onShowToast?.('No se pudo copiar el enlace. Copialo manualmente.');
+    }
   };
 
   return (
@@ -806,6 +891,96 @@ function SiniestrosModule({
             );
           })}
         </div>
+      </section>
+
+      <section className="grid grid--two">
+        <article className="card">
+          <header className="card__header">
+            <h3>Portal digital para peritos</h3>
+          </header>
+          <ul className="perito-list">
+            {inspections.length === 0 ? (
+              <li className="form-helper">No hay enlaces generados para peritos.</li>
+            ) : (
+              inspections.map((inspection) => (
+                <li key={inspection.claimId} className="perito-item">
+                  <div>
+                    <strong>{inspection.claimId}</strong>
+                    <small>
+                      {inspection.inspector} · Visita {formatDateTime(inspection.scheduled)}
+                    </small>
+                    <p>{inspection.observations}</p>
+                    <small>
+                      {inspection.damages?.length ?? 0} daños registrados · {inspection.parts?.length ?? 0} repuestos ·{' '}
+                      {inspection.photos} fotos
+                    </small>
+                  </div>
+                  <button className="btn btn--tiny" onClick={() => handleCopyLink(inspection.link)}>
+                    Copiar enlace
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </article>
+        <article className="card">
+          <header className="card__header">
+            <h3>Documentación crítica</h3>
+          </header>
+          <ul className="document-summary">
+            {documentationAlerts.length === 0 ? (
+              <li className="form-helper">Todos los documentos requeridos están al día.</li>
+            ) : (
+              documentationAlerts.map((document) => {
+                const meta = getDocumentMeta(document.status);
+                return (
+                  <li key={`${document.claimId}-${document.id}`} className="document-summary__item">
+                    <div>
+                      <strong>{document.label}</strong>
+                      <small>{document.claimId}</small>
+                      {document.notes && <p>{document.notes}</p>}
+                    </div>
+                    <span className={meta.className}>{meta.label}</span>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </article>
+      </section>
+
+      <section className="card">
+        <header className="card__header">
+          <div>
+            <h3>Registro de ampliaciones</h3>
+            <p className="card__helper">Daños adicionales detectados durante la reparación.</p>
+          </div>
+          <button className="btn btn--ghost" onClick={() => onShowToast?.('Exportando ampliaciones a CSV...')}>
+            Exportar CSV
+          </button>
+        </header>
+        <ul className="expansion-list">
+          {expansions.length === 0 ? (
+            <li className="form-helper">No se registraron ampliaciones en los siniestros activos.</li>
+          ) : (
+            expansions.map((expansion, index) => {
+              const meta = getExpansionMeta(expansion.status);
+              return (
+                <li key={`${expansion.claimId}-${index}`} className="expansion-item">
+                  <div>
+                    <strong>{expansion.claimId}</strong>
+                    <small>Detectado el {formatDate(expansion.date)}</small>
+                    <p>{expansion.detail}</p>
+                  </div>
+                  <div className="expansion-item__status">
+                    <span className={meta.className}>{meta.label}</span>
+                    {expansion.impact && <small>{expansion.impact}</small>}
+                  </div>
+                </li>
+              );
+            })
+          )}
+        </ul>
       </section>
 
       <section className="grid grid--two">
@@ -975,26 +1150,265 @@ function ConsultasModule({ insuredDirectory }) {
   );
 }
 
-function PlaceholderModule() {
+function RepuestosModule({ orders, onShowToast }) {
+  const data = orders ?? [];
+  const [selected, setSelected] = useState(() => data[0] ?? null);
+
+  useEffect(() => {
+    if (!orders || orders.length === 0) {
+      setSelected(null);
+      return;
+    }
+    setSelected((prev) => {
+      if (prev && orders.some((order) => order.claimId === prev.claimId)) {
+        return prev;
+      }
+      return orders[0];
+    });
+  }, [orders]);
+
+  const totalOrders = data.length;
+  const openOrders = data.filter((order) => order.status !== 'entregado').length;
+  const unavailableParts = data.reduce(
+    (acc, order) => acc + order.parts.filter((part) => part.status?.toLowerCase().includes('no disponible')).length,
+    0,
+  );
+  const totalAdjustments = data.reduce((acc, order) => acc + (order.adjustments?.length ?? 0), 0);
+
+  const partStatusClass = (status) => {
+    if (!status) return 'tag';
+    const normalized = status.toLowerCase();
+    if (normalized.includes('no disponible')) return 'tag tag--danger';
+    if (normalized.includes('encarg')) return 'tag tag--warning';
+    if (normalized.includes('cotiz')) return 'tag tag--warning';
+    if (normalized.includes('comprado')) return 'tag tag--success';
+    if (normalized.includes('entregado') || normalized.includes('listo')) return 'tag tag--success';
+    return 'tag';
+  };
+
+  const handleExportOrder = () => {
+    onShowToast?.('Generando archivo para liquidación de consorcio...');
+  };
+
+  const handleScheduleSftp = () => {
+    onShowToast?.('Programando envío SFTP al sistema de liquidación.');
+  };
+
   return (
     <section className="module">
       <div className="module__header">
         <div>
           <h2>Gestión de repuestos</h2>
-          <p>Módulo en diseño. Permitirá solicitar, aprobar y conciliar repuestos.</p>
+          <p>Centraliza cotizaciones, pedidos y entregas vinculadas a cada siniestro.</p>
         </div>
       </div>
-      <section className="card placeholder">
-        <h3>Próximamente</h3>
-        <p>
-          El módulo de repuestos incluirá integración con talleres, seguimiento de pedidos y control de stock.
-        </p>
-        <ul>
-          <li>Catálogo de repuestos homologados</li>
-          <li>Integración con compras y proveedores</li>
-          <li>Alertas por demoras de entrega</li>
-        </ul>
+
+      <div className="grid grid--stats">
+        <article className="stat-card">
+          <h3>Pedidos activos</h3>
+          <p className="stat-card__value">{totalOrders}</p>
+          <span className="stat-card__detail">Casos con repuestos en seguimiento</span>
+        </article>
+        <article className="stat-card">
+          <h3>En gestión</h3>
+          <p className="stat-card__value">{openOrders}</p>
+          <span className="stat-card__detail">Pendientes de entrega</span>
+        </article>
+        <article className="stat-card">
+          <h3>Sin disponibilidad</h3>
+          <p className="stat-card__value">{unavailableParts}</p>
+          <span className="stat-card__detail">Piezas con búsqueda activa</span>
+        </article>
+        <article className="stat-card">
+          <h3>Ajustes registrados</h3>
+          <p className="stat-card__value">{totalAdjustments}</p>
+          <span className="stat-card__detail">Modificaciones de precios o condiciones</span>
+        </article>
+      </div>
+
+      <section className="card">
+        <header className="card__header">
+          <div>
+            <h3>Tablero de pedidos</h3>
+            <p className="card__helper">Visualiza el estado y próximos pasos por siniestro.</p>
+          </div>
+        </header>
+        <div className="parts-table">
+          {data.length === 0 ? (
+            <p className="form-helper">No hay pedidos de repuestos registrados.</p>
+          ) : (
+            <table>
+              <thead>
+                <tr>
+                  <th>Siniestro</th>
+                  <th>Taller</th>
+                  <th>Estado</th>
+                  <th>Próximo paso</th>
+                  <th>Plazo objetivo</th>
+                  <th>Contacto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((order) => (
+                  <tr
+                    key={order.claimId}
+                    className={selected?.claimId === order.claimId ? 'is-selected' : ''}
+                    onClick={() => setSelected(order)}
+                  >
+                    <td>
+                      <strong>{order.claimId}</strong>
+                      <small>{order.vehicle}</small>
+                    </td>
+                    <td>
+                      <strong>{order.workshop}</strong>
+                      <small>{order.consorcio}</small>
+                    </td>
+                    <td>
+                      <span className={`tag parts-status parts-status--${order.status}`}>{order.statusLabel}</span>
+                      <small>Actualizado {formatDateTime(order.lastUpdate)}</small>
+                    </td>
+                    <td>
+                      <p>{order.nextStep}</p>
+                    </td>
+                    <td>
+                      <strong>{formatDate(order.dueDate)}</strong>
+                      <small>Entrega estimada</small>
+                    </td>
+                    <td>
+                      <strong>{order.contact?.name}</strong>
+                      <small>{order.contact?.phone}</small>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
       </section>
+
+      {selected && (
+        <section className="card">
+          <header className="card__header">
+            <div>
+              <h3>
+                Detalle {selected.claimId} · {selected.vehicle}
+              </h3>
+              <p className="card__helper">{selected.statusLabel} · Próximo hito: {selected.nextStep}</p>
+            </div>
+            <div className="detail-actions">
+              <button className="btn btn--ghost" onClick={() => onShowToast?.('Actualización enviada al taller.')}> 
+                Notificar taller
+              </button>
+              <button className="btn btn--ghost" onClick={handleExportOrder}>
+                Exportar CSV
+              </button>
+              <button className="btn btn--ghost" onClick={handleScheduleSftp}>
+                Programar SFTP
+              </button>
+            </div>
+          </header>
+          <div className="parts-detail">
+            <div>
+              <h4>Repuestos solicitados</h4>
+              <ul className="parts-detail__list">
+                {selected.parts.length === 0 ? (
+                  <li className="history-item">Sin repuestos asociados.</li>
+                ) : (
+                  selected.parts.map((part, index) => (
+                    <li key={`${part.name}-${index}`} className="parts-detail__item">
+                      <div>
+                        <strong>{part.name}</strong>
+                        <small>{part.action}</small>
+                        <div className="parts-detail__status">
+                          <span className={partStatusClass(part.status)}>{part.status}</span>
+                          <small>Proveedor sugerido: {part.approvedProvider || 'Pendiente'}</small>
+                          <small>Entrega estimada: {formatDate(part.expectedDate)}</small>
+                        </div>
+                        {part.notes && <p>{part.notes}</p>}
+                      </div>
+                      <div className="parts-detail__quotes">
+                        {part.supplierQuotes?.map((quote, quoteIndex) => (
+                          <span key={`${part.name}-${quoteIndex}`}>
+                            {quote.provider} · {quote.price} · {quote.eta}
+                          </span>
+                        ))}
+                      </div>
+                    </li>
+                  ))
+                )}
+              </ul>
+            </div>
+            <aside className="parts-detail__sidebar">
+              <section>
+                <h4>Ajustes de precio</h4>
+                <ul className="history-list">
+                  {selected.adjustments.length === 0 ? (
+                    <li className="history-item">No hay ajustes registrados.</li>
+                  ) : (
+                    selected.adjustments.map((adjustment, index) => (
+                      <li key={`${adjustment.date}-${index}`} className="history-item">
+                        <strong>{formatDate(adjustment.date)}</strong>
+                        <p>{adjustment.description}</p>
+                        <small>{adjustment.impact} · Aprobó {adjustment.approvedBy}</small>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </section>
+              <section>
+                <h4>Ampliaciones vinculadas</h4>
+                <ul className="history-list">
+                  {selected.expansions.length === 0 ? (
+                    <li className="history-item">Sin ampliaciones en este pedido.</li>
+                  ) : (
+                    selected.expansions.map((expansion, index) => (
+                      <li key={`${expansion.date}-${index}`} className="history-item">
+                        <strong>{formatDate(expansion.date)}</strong>
+                        <p>{expansion.detail}</p>
+                        <small>{expansion.status}</small>
+                      </li>
+                    ))
+                  )}
+                </ul>
+              </section>
+            </aside>
+          </div>
+          <div className="parts-timeline">
+            <h4>Hitos del pedido</h4>
+            <ul className="timeline">
+              {selected.timeline.length === 0 ? (
+                <li className="history-item">Sin hitos registrados.</li>
+              ) : (
+                selected.timeline.map((item, index) => (
+                  <li key={`${item.date}-${index}`} className="history-item">
+                    <strong>{formatDate(item.date)}</strong>
+                    <p>{item.label}</p>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+          <footer className="parts-footer">
+            <p>
+              ¿Necesitás conciliar con contabilidad o consorcios? Exportá el detalle o programa el envío automático por SFTP.
+            </p>
+            <div className="parts-footer__actions">
+              <button className="btn btn--primary" onClick={handleExportOrder}>
+                Exportar para conciliación
+              </button>
+              <button className="btn btn--ghost" onClick={handleScheduleSftp}>
+                Configurar integración SFTP
+              </button>
+            </div>
+          </footer>
+        </section>
+      )}
+
+      {!selected && data.length > 0 && (
+        <section className="card">
+          <p className="form-helper">Selecciona un pedido para ver los detalles.</p>
+        </section>
+      )}
     </section>
   );
 }
@@ -1290,6 +1704,29 @@ function ClaimDetailModal({ claim, onClose, onSave, onAddFollowUp, onToggleTask,
       ? 'tag tag--warning'
       : 'tag tag--success';
 
+  const documentMeta = (status) => {
+    const meta = {
+      pendiente: { label: 'Pendiente', className: 'tag tag--danger' },
+      'en-proceso': { label: 'En proceso', className: 'tag tag--warning' },
+      completo: { label: 'Completo', className: 'tag tag--success' },
+      'no-aplica': { label: 'No aplica', className: 'tag' },
+    };
+    return meta[status] ?? { label: status, className: 'tag' };
+  };
+
+  const expansionMeta = (status) => {
+    if (!status) return { label: 'En análisis', className: 'tag tag--warning' };
+    const normalized = status.toLowerCase();
+    if (normalized.includes('aprob')) return { label: status, className: 'tag tag--success' };
+    if (normalized.includes('pend') || normalized.includes('revisión') || normalized.includes('revis')) {
+      return { label: status, className: 'tag tag--warning' };
+    }
+    if (normalized.includes('no aplica')) {
+      return { label: status, className: 'tag' };
+    }
+    return { label: status, className: 'tag' };
+  };
+
   return (
     <Modal
       title={`Detalle del siniestro ${claim.id}`}
@@ -1426,6 +1863,57 @@ function ClaimDetailModal({ claim, onClose, onSave, onAddFollowUp, onToggleTask,
             </li>
           ))}
         </ul>
+      </div>
+
+      <div className="detail-grid">
+        <div>
+          <p className="section-title">Documentación del siniestro</p>
+          <ul className="document-list">
+            {(claim.documentation ?? []).length === 0 ? (
+              <li className="history-item">No hay documentación configurada para este siniestro.</li>
+            ) : (
+              claim.documentation.map((document) => {
+                const meta = documentMeta(document.status);
+                return (
+                  <li key={document.id} className="history-item document-item">
+                    <div>
+                      <strong>{document.label}</strong>
+                      {document.notes && <p>{document.notes}</p>}
+                      <small>
+                        {document.lastUpdate
+                          ? `Última actualización ${formatDateTime(document.lastUpdate)}`
+                          : 'Sin registro'}
+                      </small>
+                    </div>
+                    <span className={meta.className}>{meta.label}</span>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+        <div>
+          <p className="section-title">Ampliaciones detectadas</p>
+          <ul className="history-list">
+            {(claim.expansions ?? []).length === 0 ? (
+              <li className="history-item">No se registraron ampliaciones.</li>
+            ) : (
+              claim.expansions.map((expansion, index) => {
+                const meta = expansionMeta(expansion.status);
+                return (
+                  <li key={`${expansion.date}-${index}`} className="history-item">
+                    <div className="expansion-detail__header">
+                      <strong>{formatDate(expansion.date)}</strong>
+                      <span className={meta.className}>{meta.label}</span>
+                    </div>
+                    <p>{expansion.detail}</p>
+                    {expansion.impact && <small>{expansion.impact}</small>}
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
       </div>
 
       <div className="detail-grid">

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -213,6 +213,243 @@ export const notifications = [
   },
 ];
 
+export const peritoInspections = [
+  {
+    claimId: 'SIN-2024-001',
+    link: 'https://app.lmattioli.com/peritos/SIN-2024-001',
+    scheduled: '2024-06-06T10:00:00',
+    inspector: 'Carlos Pereyra',
+    lastUpdate: '2024-06-06T15:10:00',
+    observations:
+      'Daños visibles en lateral izquierdo con deformación en puertas delantera y trasera. Se recomienda reparación con bancada.',
+    damages: [
+      { area: 'Puerta delantera izquierda', severity: 'Media', action: 'Chapa y pintura' },
+      { area: 'Guardabarros delantero', severity: 'Alta', action: 'Reemplazo' },
+    ],
+    labor: { bodyworkDays: 3, paintPanels: 4 },
+    parts: [
+      { name: 'Guardabarros delantero izquierdo', action: 'Reemplazo', status: 'Cotización' },
+      { name: 'Moldura lateral', action: 'Reposición', status: 'Incluido en stock' },
+    ],
+    photos: 12,
+  },
+  {
+    claimId: 'SIN-2024-002',
+    link: 'https://app.lmattioli.com/peritos/SIN-2024-002',
+    scheduled: '2024-05-30T14:30:00',
+    inspector: 'Mariana Ledesma',
+    lastUpdate: '2024-06-05T11:45:00',
+    observations:
+      'Robo parcial confirmado. Faltan rueda delantera derecha y espejos. Sensor ABS presenta cableado dañado.',
+    damages: [
+      { area: 'Rueda delantera derecha', severity: 'Alta', action: 'Reposición completa' },
+      { area: 'Sensor ABS', severity: 'Media', action: 'Reemplazo y calibración' },
+    ],
+    labor: { bodyworkDays: 0, paintPanels: 0 },
+    parts: [
+      { name: 'Rueda completa 18"', action: 'Compra', status: 'Encargado' },
+      { name: 'Juego de espejos', action: 'Compra', status: 'No disponible' },
+    ],
+    photos: 8,
+  },
+  {
+    claimId: 'SIN-2024-003',
+    link: 'https://app.lmattioli.com/peritos/SIN-2024-003',
+    scheduled: '2024-05-20T09:00:00',
+    inspector: 'Rodolfo Benítez',
+    lastUpdate: '2024-05-21T18:20:00',
+    observations:
+      'Impacto frontal leve. Radiador sin pérdida. Requiere alineación y calibración de ADAS.',
+    damages: [
+      { area: 'Paragolpes delantero', severity: 'Media', action: 'Reparación' },
+      { area: 'Soporte de sensor ADAS', severity: 'Media', action: 'Reemplazo' },
+    ],
+    labor: { bodyworkDays: 2, paintPanels: 2 },
+    parts: [
+      { name: 'Soporte sensor ADAS', action: 'Pedido', status: 'Comprado' },
+      { name: 'Grapas paragolpes', action: 'Pedido', status: 'Entregado' },
+    ],
+    photos: 6,
+  },
+];
+
+export const partsTracking = [
+  {
+    claimId: 'SIN-2024-001',
+    vehicle: 'Toyota Corolla XEi 2022',
+    workshop: 'Taller Central',
+    consorcio: 'Consorcio Norte',
+    status: 'cotizacion',
+    statusLabel: 'En cotización',
+    lastUpdate: '2024-06-11T09:30:00',
+    nextStep: 'Aprobar cotización y emitir orden de compra',
+    dueDate: '2024-06-14',
+    contact: { name: 'María García', phone: '+54 11 4567-2311' },
+    parts: [
+      {
+        name: 'Guardabarros delantero izquierdo',
+        action: 'Reemplazo',
+        status: 'Cotizado',
+        supplierQuotes: [
+          { provider: 'Repuestera Norte', price: '$120.000', eta: '48 hs' },
+          { provider: 'Autopartes Delta', price: '$118.500', eta: '72 hs' },
+        ],
+        approvedProvider: 'Autopartes Delta',
+        expectedDate: '2024-06-13',
+        notes: 'Proveedor solicita seña del 30% para reservar.',
+      },
+      {
+        name: 'Kit molduras laterales',
+        action: 'Reposición',
+        status: 'Encargado',
+        supplierQuotes: [{ provider: 'LM Stock interno', price: '$35.000', eta: '24 hs' }],
+        approvedProvider: 'LM Stock interno',
+        expectedDate: '2024-06-12',
+        notes: 'Salida desde depósito Pilar.',
+      },
+    ],
+    adjustments: [
+      {
+        date: '2024-06-10',
+        description: 'Proveedor Delta actualizó tarifa en 5% por variación del dólar.',
+        impact: '+$5.925',
+        approvedBy: 'Martín Cabrera',
+      },
+    ],
+    expansions: [
+      {
+        date: '2024-06-07',
+        detail: 'Se detectó daño oculto en faro izquierdo.',
+        status: 'En revisión con consorcio',
+      },
+    ],
+    timeline: [
+      { date: '2024-06-05', label: 'Solicitud enviada a proveedores' },
+      { date: '2024-06-06', label: 'Recepción de cotizaciones' },
+      { date: '2024-06-10', label: 'Ajuste de tarifa informado' },
+    ],
+  },
+  {
+    claimId: 'SIN-2024-002',
+    vehicle: 'Ford Kuga SEL 2021',
+    workshop: 'Carrocerías del Sur',
+    consorcio: 'Consorcio Sur',
+    status: 'encargado',
+    statusLabel: 'Repuestos encargados',
+    lastUpdate: '2024-06-10T16:00:00',
+    nextStep: 'Confirmar entrega parcial y gestionar piezas faltantes',
+    dueDate: '2024-06-18',
+    contact: { name: 'Gonzalo Ferreyra', phone: '+54 11 4233-3344' },
+    parts: [
+      {
+        name: 'Rueda completa 18"',
+        action: 'Compra',
+        status: 'Encargado',
+        supplierQuotes: [
+          { provider: 'Neumáticos Ruta', price: '$210.000', eta: '5 días' },
+          { provider: 'Ruedas Express', price: '$215.500', eta: '3 días' },
+        ],
+        approvedProvider: 'Ruedas Express',
+        expectedDate: '2024-06-14',
+        notes: 'Proveedor requiere pago anticipado.',
+      },
+      {
+        name: 'Juego de espejos laterales',
+        action: 'Compra',
+        status: 'No disponible',
+        supplierQuotes: [
+          { provider: 'Autopartes Sur', price: '$89.000', eta: 'Sin stock' },
+          { provider: 'Importadora Andes', price: 'En gestión', eta: '7-10 días' },
+        ],
+        approvedProvider: 'Importadora Andes',
+        expectedDate: '2024-06-19',
+        notes: 'Se evalúa alternativa nacional si no llega importación.',
+      },
+      {
+        name: 'Sensor ABS delantero',
+        action: 'Compra',
+        status: 'Comprado',
+        supplierQuotes: [{ provider: 'Electrocar', price: '$58.000', eta: '48 hs' }],
+        approvedProvider: 'Electrocar',
+        expectedDate: '2024-06-12',
+        notes: 'Confirmar calibración una vez instalado.',
+      },
+    ],
+    adjustments: [
+      {
+        date: '2024-06-09',
+        description: 'Aumento 12% en rueda importada. Se gestiona nota de crédito con consorcio.',
+        impact: '+$22.680',
+        approvedBy: 'Laura Mattioli',
+      },
+      {
+        date: '2024-06-11',
+        description: 'Proveedor ofrece alternativa nacional (-8%). En análisis.',
+        impact: '-$7.120',
+        approvedBy: 'Pendiente',
+      },
+    ],
+    expansions: [
+      {
+        date: '2024-06-05',
+        detail: 'Cableado ABS cortado detectado durante diagnóstico.',
+        status: 'Aprobado para reposición',
+      },
+    ],
+    timeline: [
+      { date: '2024-05-31', label: 'Cotización aprobada por consorcio' },
+      { date: '2024-06-03', label: 'Orden de compra emitida' },
+      { date: '2024-06-08', label: 'Proveedor confirmó despacho' },
+    ],
+  },
+  {
+    claimId: 'SIN-2024-003',
+    vehicle: 'Chevrolet Tracker Premier 2023',
+    workshop: 'Elite Motors',
+    consorcio: 'Consorcio Premium',
+    status: 'entregado',
+    statusLabel: 'Repuestos entregados',
+    lastUpdate: '2024-06-07T13:00:00',
+    nextStep: 'Verificar reparación y preparar cierre',
+    dueDate: '2024-06-12',
+    contact: { name: 'Sofía Morales', phone: '+54 11 4878-1211' },
+    parts: [
+      {
+        name: 'Paragolpes delantero',
+        action: 'Reparación',
+        status: 'Entregado',
+        supplierQuotes: [{ provider: 'Servicio Elite', price: '$74.000', eta: 'Listo' }],
+        approvedProvider: 'Servicio Elite',
+        expectedDate: '2024-06-07',
+        notes: 'Recibido y en reparación de pintura.',
+      },
+      {
+        name: 'Soporte sensor ADAS',
+        action: 'Reemplazo',
+        status: 'Comprado',
+        supplierQuotes: [{ provider: 'ADAS Parts', price: '$132.000', eta: '72 hs' }],
+        approvedProvider: 'ADAS Parts',
+        expectedDate: '2024-06-10',
+        notes: 'Coordinar calibración posterior.',
+      },
+    ],
+    adjustments: [
+      {
+        date: '2024-06-02',
+        description: 'Aplicado descuento 5% por convenio premium.',
+        impact: '-$10.200',
+        approvedBy: 'Sofía Morales',
+      },
+    ],
+    expansions: [],
+    timeline: [
+      { date: '2024-05-28', label: 'Cotización confirmada' },
+      { date: '2024-05-30', label: 'Compra aprobada' },
+      { date: '2024-06-04', label: 'Entrega parcial' },
+    ],
+  },
+];
+
 export const catalogSummary = {
   roles: [
     { name: 'Admin', permissions: ['Gestiona catálogos', 'Define reglas', 'Gestiona usuarios'] },
@@ -245,6 +482,41 @@ export const claims = [
     assignedPerson: 'María García',
     inspectionDate: '2024-06-06',
     fastTrackNotes: '',
+    documentation: [
+      { id: 'factura-repuestos', label: 'Factura compra repuestos', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'factura-taller', label: 'Factura taller', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'factura-abogado', label: 'Factura abogado', status: 'no-aplica', lastUpdate: null, notes: 'Solo si interviene recupero.' },
+      {
+        id: 'comprobante-pago',
+        label: 'Comprobante de pago',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-05T15:45:00',
+        notes: 'Pago parcial pendiente de confirmación bancaria.',
+      },
+      {
+        id: 'informe-perito',
+        label: 'Informe del perito',
+        status: 'completo',
+        lastUpdate: '2024-06-06T15:10:00',
+        notes: 'Informe cargado por Carlos Pereyra.',
+      },
+      { id: 'fotos', label: 'Fotos del siniestro', status: 'completo', lastUpdate: '2024-06-05T12:00:00', notes: '' },
+      {
+        id: 'observaciones',
+        label: 'Observaciones / Notas',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-05T15:45:00',
+        notes: 'Esperando respuesta del asegurado.',
+      },
+    ],
+    expansions: [
+      {
+        date: '2024-06-07',
+        detail: 'Se detectó daño oculto en faro izquierdo durante desmontaje.',
+        status: 'En revisión con consorcio',
+        impact: 'Agregar repuesto y 1 día de taller.',
+      },
+    ],
     history: [
       {
         date: '2024-06-03T09:10:00',
@@ -304,6 +576,59 @@ export const claims = [
     assignedPerson: 'Gonzalo Ferreyra',
     inspectionDate: '2024-05-30',
     fastTrackNotes: '',
+    documentation: [
+      {
+        id: 'factura-repuestos',
+        label: 'Factura compra repuestos',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-09T10:00:00',
+        notes: 'Aguardando nota de crédito por ajuste.',
+      },
+      {
+        id: 'factura-taller',
+        label: 'Factura taller',
+        status: 'pendiente',
+        lastUpdate: null,
+        notes: 'Se emitirá al finalizar reparación.',
+      },
+      {
+        id: 'remitos',
+        label: 'Remitos de recepción',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-08T16:00:00',
+        notes: 'Falta remito de Importadora Andes.',
+      },
+      {
+        id: 'comprobante-pago',
+        label: 'Comprobante de pago',
+        status: 'pendiente',
+        lastUpdate: null,
+        notes: 'Pago anticipado pendiente de autorización.',
+      },
+      {
+        id: 'informe-perito',
+        label: 'Informe del perito',
+        status: 'completo',
+        lastUpdate: '2024-05-30T18:00:00',
+        notes: 'Inspección Mariana Ledesma.',
+      },
+      { id: 'fotos', label: 'Fotos del siniestro', status: 'completo', lastUpdate: '2024-05-30T18:05:00', notes: '' },
+      {
+        id: 'observaciones',
+        label: 'Observaciones / Notas',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-05T09:12:00',
+        notes: 'Demora en espejos importados.',
+      },
+    ],
+    expansions: [
+      {
+        date: '2024-06-05',
+        detail: 'Cableado ABS cortado detectado durante inspección taller.',
+        status: 'Aprobado para reposición',
+        impact: 'Sumar repuesto y calibración.',
+      },
+    ],
     history: [
       {
         date: '2024-05-29T10:24:00',
@@ -365,6 +690,40 @@ export const claims = [
     assignedPerson: 'Julieta López',
     inspectionDate: null,
     fastTrackNotes: 'Cliente aceptó reparación express en fast track.',
+    documentation: [
+      {
+        id: 'factura-repuestos',
+        label: 'Factura compra repuestos',
+        status: 'completo',
+        lastUpdate: '2024-05-30T11:00:00',
+        notes: 'Factura ADAS Parts 00231.',
+      },
+      {
+        id: 'factura-taller',
+        label: 'Factura taller',
+        status: 'en-proceso',
+        lastUpdate: '2024-06-06T17:30:00',
+        notes: 'Cierre previsto con entrega final.',
+      },
+      { id: 'remitos', label: 'Remitos de recepción', status: 'completo', lastUpdate: '2024-06-04T13:00:00', notes: '' },
+      { id: 'comprobante-pago', label: 'Comprobante de pago', status: 'pendiente', lastUpdate: null, notes: '' },
+      {
+        id: 'informe-perito',
+        label: 'Informe del perito',
+        status: 'completo',
+        lastUpdate: '2024-05-21T18:20:00',
+        notes: 'Incluye calibración ADAS.',
+      },
+      { id: 'fotos', label: 'Fotos del siniestro', status: 'completo', lastUpdate: '2024-05-21T18:25:00', notes: '' },
+      {
+        id: 'observaciones',
+        label: 'Observaciones / Notas',
+        status: 'en-proceso',
+        lastUpdate: '2024-05-27T11:00:00',
+        notes: 'Esperando confirmación de calibración.',
+      },
+    ],
+    expansions: [],
     history: [
       {
         date: '2024-05-20T10:42:00',
@@ -421,6 +780,28 @@ export const claims = [
     assignedPerson: null,
     inspectionDate: null,
     fastTrackNotes: '',
+    documentation: [
+      {
+        id: 'factura-repuestos',
+        label: 'Factura compra repuestos',
+        status: 'pendiente',
+        lastUpdate: null,
+        notes: 'Se definirá si aplica tras inspección.',
+      },
+      {
+        id: 'factura-taller',
+        label: 'Factura taller',
+        status: 'pendiente',
+        lastUpdate: null,
+        notes: 'A definir taller.',
+      },
+      { id: 'remitos', label: 'Remitos de recepción', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'comprobante-pago', label: 'Comprobante de pago', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'informe-perito', label: 'Informe del perito', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'fotos', label: 'Fotos del siniestro', status: 'pendiente', lastUpdate: null, notes: '' },
+      { id: 'observaciones', label: 'Observaciones / Notas', status: 'pendiente', lastUpdate: null, notes: '' },
+    ],
+    expansions: [],
     history: [
       {
         date: '2024-06-08T08:22:00',
@@ -460,6 +841,45 @@ export const claims = [
     assignedPerson: 'Julieta López',
     inspectionDate: null,
     fastTrackNotes: 'Liquidación automática y reintegro a la asegurada.',
+    documentation: [
+      {
+        id: 'factura-repuestos',
+        label: 'Factura compra repuestos',
+        status: 'no-aplica',
+        lastUpdate: '2024-05-03T10:22:00',
+        notes: 'Caso fast track sin intervención de taller.',
+      },
+      {
+        id: 'factura-taller',
+        label: 'Factura taller',
+        status: 'no-aplica',
+        lastUpdate: '2024-05-03T10:22:00',
+        notes: '',
+      },
+      {
+        id: 'comprobante-pago',
+        label: 'Comprobante de pago',
+        status: 'completo',
+        lastUpdate: '2024-05-15T16:01:00',
+        notes: 'Transferencia realizada a la asegurada.',
+      },
+      {
+        id: 'informe-perito',
+        label: 'Informe del perito',
+        status: 'completo',
+        lastUpdate: '2024-05-06T11:55:00',
+        notes: 'Revisión digital fast track.',
+      },
+      { id: 'fotos', label: 'Fotos del siniestro', status: 'completo', lastUpdate: '2024-05-03T10:22:00', notes: '' },
+      {
+        id: 'observaciones',
+        label: 'Observaciones / Notas',
+        status: 'completo',
+        lastUpdate: '2024-05-13T09:10:00',
+        notes: 'Consorcio aprobó reintegro.',
+      },
+    ],
+    expansions: [],
     history: [
       {
         date: '2024-05-03T10:22:00',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -805,6 +805,214 @@ a {
   max-width: 360px;
 }
 
+.card__helper {
+  font-size: 14px;
+  color: var(--color-muted);
+}
+
+.perito-list,
+.document-summary,
+.expansion-list,
+.document-list,
+.parts-detail__list,
+.parts-detail__quotes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.perito-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(0, 68, 170, 0.14);
+  background: rgba(248, 250, 255, 0.8);
+}
+
+.perito-item strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.perito-item small {
+  display: block;
+  color: var(--color-muted);
+  margin-top: 4px;
+}
+
+.document-summary__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-medium);
+  padding: 14px 16px;
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.document-summary__item p {
+  margin-top: 6px;
+  color: var(--color-muted);
+  max-width: 360px;
+}
+
+.document-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.document-item p {
+  margin: 6px 0;
+  color: var(--color-muted);
+}
+
+.expansion-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: var(--radius-medium);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(248, 250, 255, 0.9);
+}
+
+.expansion-item__status {
+  display: grid;
+  gap: 6px;
+  text-align: right;
+  justify-items: end;
+}
+
+.expansion-item__status small {
+  color: var(--color-muted);
+}
+
+.expansion-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.parts-table {
+  overflow-x: auto;
+}
+
+.parts-table table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+.parts-table th,
+.parts-table td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.parts-table tbody tr {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.parts-table tbody tr:hover {
+  background: rgba(226, 237, 255, 0.4);
+}
+
+.parts-table tbody tr.is-selected {
+  background: rgba(14, 159, 110, 0.08);
+}
+
+.parts-status {
+  display: inline-flex;
+  margin-bottom: 6px;
+}
+
+.parts-detail {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(320px, 1fr) 320px;
+}
+
+.parts-detail__item {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-medium);
+  padding: 14px 16px;
+  background: rgba(248, 250, 255, 0.9);
+  display: grid;
+  gap: 10px;
+}
+
+.parts-detail__status {
+  display: grid;
+  gap: 4px;
+  align-items: start;
+}
+
+.parts-detail__quotes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--color-muted);
+}
+
+.parts-detail__sidebar {
+  display: grid;
+  gap: 20px;
+}
+
+.parts-detail__sidebar section {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-medium);
+  padding: 16px;
+  background: rgba(248, 250, 255, 0.95);
+  display: grid;
+  gap: 12px;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.parts-timeline {
+  margin-top: 24px;
+  display: grid;
+  gap: 12px;
+}
+
+.parts-footer {
+  margin-top: 20px;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.parts-footer p {
+  max-width: 520px;
+  color: var(--color-muted);
+}
+
+.parts-footer__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 @media (max-width: 1024px) {
   .sidebar {
     display: none;
@@ -822,6 +1030,14 @@ a {
   .topbar__actions {
     justify-content: space-between;
   }
+
+  .parts-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 680px) {
@@ -836,5 +1052,23 @@ a {
 
   .kanban {
     grid-template-columns: 1fr;
+  }
+
+  .perito-item,
+  .expansion-item,
+  .document-summary__item {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .expansion-item__status {
+    justify-items: flex-start;
+    text-align: left;
+  }
+
+  .parts-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,6 +9,8 @@ export function cloneClaims(list) {
     followUps: claim.followUps ? claim.followUps.map((f) => ({ ...f })) : [],
     attachments: claim.attachments ? claim.attachments.map((a) => ({ ...a })) : [],
     tasks: claim.tasks ? claim.tasks.map((t) => ({ ...t })) : [],
+    documentation: claim.documentation ? claim.documentation.map((doc) => ({ ...doc })) : [],
+    expansions: claim.expansions ? claim.expansions.map((expansion) => ({ ...expansion })) : [],
   }));
 }
 


### PR DESCRIPTION
## Summary
- enrich claim data with documentación, ampliaciones y formularios de perito
- expand el módulo de siniestros con panel para peritos, alertas de documentación y registro de ampliaciones
- reemplazar el placeholder de repuestos por un tablero interactivo con seguimiento de pedidos, ajustes y exportaciones
- actualizar estilos para los nuevos listados y tarjetas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da89d6d0c0832e8ad6412fb39ca1e9